### PR TITLE
Add ability to read CSV files

### DIFF
--- a/BatchRvtGUI/BatchRvtGuiForm.cs
+++ b/BatchRvtGUI/BatchRvtGuiForm.cs
@@ -689,7 +689,7 @@ namespace BatchRvtGUI
             var openFileDialog = new OpenFileDialog();
 
             openFileDialog.DefaultExt = ".txt";
-            openFileDialog.Filter = "Revit File List (*.txt;*.xls;*.xlsx)|*.txt;*.xls;*.xlsx";
+            openFileDialog.Filter = "Revit File List (*.txt;*.xls;*.xlsx;*.csv)|*.txt;*.xls;*.xlsx;*.csv";
             openFileDialog.CheckFileExists = true;
             openFileDialog.ReadOnlyChecked = true;
             openFileDialog.Multiselect = false;

--- a/BatchRvtUtil/Scripts/csv_util.py
+++ b/BatchRvtUtil/Scripts/csv_util.py
@@ -23,11 +23,21 @@ import System
 
 from System.Text import Encoding
 from System.IO import File
+import path_util
 
-def ReadFromCSVFile(csvFilePath, delimiter, encoding):
-  lines = File.ReadAllLines(csvFilePath, encoding)
-  rows = [[value for value in line.Split(delimiter)] for line in lines]
-  return rows
+CSV_FILE_EXTENSION = ".csv"
+
+def ReadAllLines(filePath):
+  lines = File.ReadAllLines(filePath)
+  if len(lines) > 0: # Workaround for a potential lack of detection of Unicode txt files.
+    if lines[0].Contains("\x00"):
+      lines = File.ReadAllLines(filePath, Encoding.Unicode)
+  return lines
+
+def ReadFromCSVFile(csvFilePath):
+  lines = ReadAllLines(csvFilePath)
+  return [[path] for line in lines for path in line.split(',')]
+
 
 def WriteToCSVFile(rows, csvFilePath, delimiter, encoding):
   lines = [str.Join(delimiter, [str(value) for value in row]) for row in rows]
@@ -37,3 +47,11 @@ def WriteToCSVFile(rows, csvFilePath, delimiter, encoding):
 def WriteToTabDelimitedTxtFile(rows, txtFilePath, encoding=Encoding.UTF8):
   WriteToCSVFile(rows, txtFilePath, "\t", encoding)
   return
+
+def HasCSVFileExtension(filePath):
+  return path_util.HasFileExtension(filePath, CSV_FILE_EXTENSION)
+
+def GetRowsFromCSVFile(csvFilePath):
+  # Support files listed by row or by column
+  rows = ReadFromCSVFile(csvFilePath)
+  return rows

--- a/BatchRvtUtil/Scripts/csv_util.py
+++ b/BatchRvtUtil/Scripts/csv_util.py
@@ -34,10 +34,8 @@ def ReadAllLines(filePath):
       lines = File.ReadAllLines(filePath, Encoding.Unicode)
   return lines
 
-def ReadFromCSVFile(csvFilePath):
-  lines = ReadAllLines(csvFilePath)
-  return [[path] for line in lines for path in line.split(',')]
-
+def GetRowsFromLines(lines):
+  return [line.split(',') for line in lines]
 
 def WriteToCSVFile(rows, csvFilePath, delimiter, encoding):
   lines = [str.Join(delimiter, [str(value) for value in row]) for row in rows]
@@ -52,6 +50,5 @@ def HasCSVFileExtension(filePath):
   return path_util.HasFileExtension(filePath, CSV_FILE_EXTENSION)
 
 def GetRowsFromCSVFile(csvFilePath):
-  # Support files listed by row or by column
-  rows = ReadFromCSVFile(csvFilePath)
-  return rows
+  lines = ReadAllLines(csvFilePath)
+  return GetRowsFromLines(lines)

--- a/BatchRvtUtil/Scripts/revit_file_list.py
+++ b/BatchRvtUtil/Scripts/revit_file_list.py
@@ -24,6 +24,7 @@ from System import ArgumentException, NotSupportedException
 from System.IO import PathTooLongException
 
 import text_file_util
+import csv_util
 import console_util
 import path_util
 import revit_file_version
@@ -55,6 +56,10 @@ def FromText(text):
 def FromLines(lines):
   rows = text_file_util.GetRowsFromLines(lines)
   return GetCentralFileListFromRows(rows)
+
+def FromCSVFile(csvFilePath):
+    rows = csv_util.GetRowsFromCSVFile(csvFilePath)
+    return GetCentralFileListFromRows(rows)
 
 def IsExcelInstalled():
   return System.Type.GetTypeFromProgID("Excel.Application") is not None
@@ -111,6 +116,8 @@ def GetRevitFileList(settingsFilePath):
   revitFileList = None
   if text_file_util.HasTextFileExtension(settingsFilePath):
     revitFileList = FromTextFile(settingsFilePath)
+  elif csv_util.HasCSVFileExtension(settingsFilePath):
+    revitFileList = FromCSVFile(settingsFilePath)
   elif HasExcelFileExtension(settingsFilePath):
     revitFileList = FromExcelFile(settingsFilePath)
   return revitFileList


### PR DESCRIPTION
Files can be listed out in rows or columns (or both).

Example CSV:
```
fileA,fileB,fileC
```
Converts to:
```
[['fileA'], ['fileB'], ['fileC']]
```
Similar to how the `.txt` parser is done.
Resolves #40 