### PR TITLE
Add rebuild clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Revit addins will be automatically deployed to the Addins folder for each availa
 
 The BatchRvtGUI project is the GUI that drives the underlying engine (the BatchRvt project). Once built, run BatchRvtGUI.exe to start the Revit Batch Processor GUI.
 
+When rebuilding, please make sure all Revit applications are closed before attempting the rebuild.
+
 # Requirements
 
 - At least one version of Revit installed. Currently supports Revit versions 2015 through 2020.


### PR DESCRIPTION
I had Revit 2019 open when rebuilding the solution. The solution failed because it wasn't able to delete %APPDATA%\Autodesk\Revit\Addins\2019\BatchRvt

While this isn't a problem for the initial installation (since Revit won't be using the folder), this could be a problem in the future for those that want to upgrade their RBP version.