### PR TITLE
Support for Revit installed on D: drive and UI Option to Ignore Revit backup files.

### DIFF
--- a/BatchRvtGUI/BatchRvtGuiForm.cs
+++ b/BatchRvtGUI/BatchRvtGuiForm.cs
@@ -1152,6 +1152,7 @@ namespace BatchRvtGUI
 
                         bool expandNetworkPaths = revitFileScanningOptionsUI.ExpandNetworkPaths();
                         bool extractRevitVersionInfo = revitFileScanningOptionsUI.ExtractRevitVersionInfo();
+                        bool ignoreRevitBackupFiles = revitFileScanningOptionsUI.IgnoreRevitBackupFiles();
 
                         var rows = Enumerable.Empty<IEnumerable<string>>();
 
@@ -1163,6 +1164,7 @@ namespace BatchRvtGUI
                                     selectedRevitFileType,
                                     expandNetworkPaths,
                                     extractRevitVersionInfo,
+                                    ignoreRevitBackupFiles,
                                     progressReporter
                                 );
                             };

--- a/BatchRvtGUI/RevitFileScanningOptionsUI.Designer.cs
+++ b/BatchRvtGUI/RevitFileScanningOptionsUI.Designer.cs
@@ -32,6 +32,7 @@
             this.startScanButton = new System.Windows.Forms.Button();
             this.optionsGroupBox = new System.Windows.Forms.GroupBox();
             this.otherOptionsGroupBox = new System.Windows.Forms.GroupBox();
+            this.ignoreBackupFilesCheckBox = new System.Windows.Forms.CheckBox();
             this.asteriskNoteLabel = new System.Windows.Forms.Label();
             this.detectRevitFileVersionCheckBox = new System.Windows.Forms.CheckBox();
             this.expandNetworkPathsCheckBox = new System.Windows.Forms.CheckBox();
@@ -49,7 +50,7 @@
             // 
             this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(309, 171);
+            this.cancelButton.Location = new System.Drawing.Point(308, 185);
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(75, 23);
             this.cancelButton.TabIndex = 2;
@@ -60,7 +61,7 @@
             // 
             this.startScanButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.startScanButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.startScanButton.Location = new System.Drawing.Point(165, 171);
+            this.startScanButton.Location = new System.Drawing.Point(164, 185);
             this.startScanButton.Name = "startScanButton";
             this.startScanButton.Size = new System.Drawing.Size(138, 23);
             this.startScanButton.TabIndex = 1;
@@ -73,28 +74,41 @@
             this.optionsGroupBox.Controls.Add(this.revitFileTypesGroupBox);
             this.optionsGroupBox.Location = new System.Drawing.Point(12, 12);
             this.optionsGroupBox.Name = "optionsGroupBox";
-            this.optionsGroupBox.Size = new System.Drawing.Size(372, 148);
+            this.optionsGroupBox.Size = new System.Drawing.Size(372, 163);
             this.optionsGroupBox.TabIndex = 0;
             this.optionsGroupBox.TabStop = false;
             this.optionsGroupBox.Text = "Options";
             // 
             // otherOptionsGroupBox
             // 
+            this.otherOptionsGroupBox.Controls.Add(this.ignoreBackupFilesCheckBox);
             this.otherOptionsGroupBox.Controls.Add(this.asteriskNoteLabel);
             this.otherOptionsGroupBox.Controls.Add(this.detectRevitFileVersionCheckBox);
             this.otherOptionsGroupBox.Controls.Add(this.expandNetworkPathsCheckBox);
             this.otherOptionsGroupBox.Controls.Add(this.includeSubfoldersCheckBox);
             this.otherOptionsGroupBox.Location = new System.Drawing.Point(165, 19);
             this.otherOptionsGroupBox.Name = "otherOptionsGroupBox";
-            this.otherOptionsGroupBox.Size = new System.Drawing.Size(194, 117);
+            this.otherOptionsGroupBox.Size = new System.Drawing.Size(194, 134);
             this.otherOptionsGroupBox.TabIndex = 1;
             this.otherOptionsGroupBox.TabStop = false;
             this.otherOptionsGroupBox.Text = "Additional Options";
             // 
+            // ignoreBackupFilesCheckBox
+            // 
+            this.ignoreBackupFilesCheckBox.AutoSize = true;
+            this.ignoreBackupFilesCheckBox.Checked = true;
+            this.ignoreBackupFilesCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.ignoreBackupFilesCheckBox.Location = new System.Drawing.Point(6, 88);
+            this.ignoreBackupFilesCheckBox.Name = "ignoreBackupFilesCheckBox";
+            this.ignoreBackupFilesCheckBox.Size = new System.Drawing.Size(167, 17);
+            this.ignoreBackupFilesCheckBox.TabIndex = 4;
+            this.ignoreBackupFilesCheckBox.Text = "Ignore backup files (.0001.rvt)";
+            this.ignoreBackupFilesCheckBox.UseVisualStyleBackColor = true;
+            // 
             // asteriskNoteLabel
             // 
             this.asteriskNoteLabel.AutoSize = true;
-            this.asteriskNoteLabel.Location = new System.Drawing.Point(21, 90);
+            this.asteriskNoteLabel.Location = new System.Drawing.Point(22, 108);
             this.asteriskNoteLabel.Name = "asteriskNoteLabel";
             this.asteriskNoteLabel.Size = new System.Drawing.Size(162, 13);
             this.asteriskNoteLabel.TabIndex = 3;
@@ -137,7 +151,7 @@
             this.revitFileTypesGroupBox.Controls.Add(this.familyFilesRadioButton);
             this.revitFileTypesGroupBox.Location = new System.Drawing.Point(6, 19);
             this.revitFileTypesGroupBox.Name = "revitFileTypesGroupBox";
-            this.revitFileTypesGroupBox.Size = new System.Drawing.Size(153, 117);
+            this.revitFileTypesGroupBox.Size = new System.Drawing.Size(153, 134);
             this.revitFileTypesGroupBox.TabIndex = 0;
             this.revitFileTypesGroupBox.TabStop = false;
             this.revitFileTypesGroupBox.Text = "Revit File Types";
@@ -178,7 +192,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(396, 206);
+            this.ClientSize = new System.Drawing.Size(395, 220);
             this.Controls.Add(this.optionsGroupBox);
             this.Controls.Add(this.startScanButton);
             this.Controls.Add(this.cancelButton);
@@ -209,6 +223,7 @@
         private System.Windows.Forms.CheckBox includeSubfoldersCheckBox;
         private System.Windows.Forms.GroupBox otherOptionsGroupBox;
         private System.Windows.Forms.CheckBox detectRevitFileVersionCheckBox;
+        private System.Windows.Forms.CheckBox ignoreBackupFilesCheckBox;
         private System.Windows.Forms.Label asteriskNoteLabel;
     }
 }

--- a/BatchRvtGUI/RevitFileScanningOptionsUI.cs
+++ b/BatchRvtGUI/RevitFileScanningOptionsUI.cs
@@ -71,5 +71,10 @@ namespace BatchRvtGUI
         {
             return this.detectRevitFileVersionCheckBox.Checked;
         }
+
+        public bool IgnoreRevitBackupFiles()
+        {
+            return this.ignoreBackupFilesCheckBox.Checked;
+        }
     }
 }

--- a/BatchRvtUtil/RevitFileScanning.cs
+++ b/BatchRvtUtil/RevitFileScanning.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace BatchRvtUtil
 {
@@ -41,6 +42,7 @@ namespace BatchRvtUtil
                 RevitFileType revitFileType,
                 bool expandNetworkPaths,
                 bool extractRevitVersionInfo,
+                bool ignoreRevitBackupFiles,
                 Func<string, bool> progressReporter
             )
         {
@@ -48,7 +50,7 @@ namespace BatchRvtUtil
 
             progressReporter("Scanning for Revit files ...");
 
-            var revitFilePaths = FindRevitFiles(baseFolderPath, searchOption, revitFileType, progressReporter);
+            var revitFilePaths = FindRevitFiles(baseFolderPath, searchOption, revitFileType, ignoreRevitBackupFiles, progressReporter);
 
             int numberOfRevitFilePaths = revitFilePaths.Count();
 
@@ -119,6 +121,7 @@ namespace BatchRvtUtil
                 string folderPath,
                 SearchOption searchOption,
                 RevitFileType revitFileType,
+                bool ignoreRevitBackups,
                 Func<string, bool> progressReporter
             )
         {
@@ -164,35 +167,70 @@ namespace BatchRvtUtil
 
                 revitFilePaths.AddRange(
                         PathUtil.SafeEnumerateFiles(folderToScan, searchFilePattern, SearchOption.TopDirectoryOnly)
-                        .Where(filePath => HasRevitFileExtension(filePath))
+                        .Where(filePath => HasRevitFileExtension(filePath, ignoreRevitBackups))
                     );
             }
 
             return revitFilePaths;
         }
 
-        public static bool HasRevitProjectFileExtension(string filePath)
+        public static bool HasRevitProjectFileExtension(string filePath, bool ignoreRevitBackups)
         {
             var extension = Path.GetExtension(filePath).ToLower();
 
-            return extension.ToLower() == REVIT_PROJECT_FILE_EXTENSION;
+            if (ignoreRevitBackups && IsBackupFile(filePath))
+            {
+                return false;
+            }
+            else
+            {
+                return extension.ToLower() == REVIT_PROJECT_FILE_EXTENSION;
+            }
         }
 
-        public static bool HasRevitFamilyFileExtension(string filePath)
+        public static bool HasRevitFamilyFileExtension(string filePath, bool ignoreRevitBackups)
         {
             var extension = Path.GetExtension(filePath).ToLower();
 
-            return extension.ToLower() == REVIT_FAMILY_FILE_EXTENSION;
+            if (ignoreRevitBackups && IsBackupFile(filePath))
+            {
+                return false;
+            }
+            else
+            {
+                return extension.ToLower() == REVIT_FAMILY_FILE_EXTENSION;
+            }
         }
 
-        public static bool HasRevitFileExtension(string filePath)
+        public static bool HasRevitFileExtension(string filePath, bool ignoreRevitBackups)
         {
             var extension = Path.GetExtension(filePath).ToLower();
 
-            return new[] {
+            if (ignoreRevitBackups && IsBackupFile(filePath))
+            {
+                return false;
+            }
+            else
+            {
+                return new[] {
                     REVIT_PROJECT_FILE_EXTENSION,
                     REVIT_FAMILY_FILE_EXTENSION
                 }.Any(revitExtension => extension == revitExtension.ToLower());
+            }
+        }
+
+        private static bool IsBackupFile(string filePath)
+        {
+            string pattern = "\\.\\d\\d\\d\\d.(rvt|rfa)$";
+            if (Regex.IsMatch(filePath, pattern))
+            {
+                // This is a backup version of the file (ie. .0001.rvt/rfa) so skip it.
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
     }
 }

--- a/BatchRvtUtil/RevitVersion.cs
+++ b/BatchRvtUtil/RevitVersion.cs
@@ -66,38 +66,47 @@ namespace BatchRvtUtil
                     SupportedRevitVersion.Revit2015,
                     new [] {
                         @"C:\Program Files\Autodesk\Revit 2015",
-                        @"C:\Program Files\Autodesk\Revit Architecture 2015"
+                        @"C:\Program Files\Autodesk\Revit Architecture 2015",
+                        @"D:\Program Files\Autodesk\Revit 2015",
+                        @"D:\Program Files\Autodesk\Revit Architecture 2015"
                     }
                 },
                 {
                     SupportedRevitVersion.Revit2016,
                     new [] {
                         @"C:\Program Files\Autodesk\Revit 2016",
-                        @"C:\Program Files\Autodesk\Revit Architecture 2016"
+                        @"C:\Program Files\Autodesk\Revit Architecture 2016",
+                        @"D:\Program Files\Autodesk\Revit 2016",
+                        @"D:\Program Files\Autodesk\Revit Architecture 2016",
                     }
                 },
                 {
                     SupportedRevitVersion.Revit2017,
                     new [] {
-                        @"C:\Program Files\Autodesk\Revit 2017"
+                        @"C:\Program Files\Autodesk\Revit 2017",
+                        @"D:\Program Files\Autodesk\Revit 2017"
                     }
                 },
                 {
                     SupportedRevitVersion.Revit2018,
                     new [] {
-                        @"C:\Program Files\Autodesk\Revit 2018"
+                        @"C:\Program Files\Autodesk\Revit 2018",
+                        @"D:\Program Files\Autodesk\Revit 2018"
                     }
                 },
                 {
                     SupportedRevitVersion.Revit2019,
                     new [] {
-                        @"C:\Program Files\Autodesk\Revit 2019"
+                        @"C:\Program Files\Autodesk\Revit 2019",
+                        @"D:\Program Files\Autodesk\Revit 2019"
+
                     }
                 },
                 {
                     SupportedRevitVersion.Revit2020,
                     new [] {
-                        @"C:\Program Files\Autodesk\Revit 2020"
+                        @"C:\Program Files\Autodesk\Revit 2020",
+                        @"D:\Program Files\Autodesk\Revit 2020"
                     }
                 }
             };


### PR DESCRIPTION
Added Revit detection support for Revit installed on D: drive (since without this the Batch Processor will not run if Revit is not installed in typical C: location). Maybe there's a more elegant way to fix this but it works for me for now.

Also added a UI option to Ignore Revit Backup files (.0001.rvt and .0001.rfa).