### PR TITLE
Update to .Net Framework 4.8

### DIFF
--- a/BatchRevitDynamo/BatchRevitDynamo.csproj
+++ b/BatchRevitDynamo/BatchRevitDynamo.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BatchRevitDynamo</RootNamespace>
     <AssemblyName>BatchRevitDynamo</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/BatchRvt/BatchRvt.csproj
+++ b/BatchRvt/BatchRvt.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BatchRvt</RootNamespace>
     <AssemblyName>BatchRvt</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup>

--- a/BatchRvtAddin2015/BatchRvtAddin2015.csproj
+++ b/BatchRvtAddin2015/BatchRvtAddin2015.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BatchRvt.Addin.Revit2015</RootNamespace>
     <AssemblyName>BatchRvtAddin2015</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/BatchRvtAddin2016/BatchRvtAddin2016.csproj
+++ b/BatchRvtAddin2016/BatchRvtAddin2016.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BatchRvt.Addin.Revit2016</RootNamespace>
     <AssemblyName>BatchRvtAddin2016</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/BatchRvtAddin2017/BatchRvtAddin2017.csproj
+++ b/BatchRvtAddin2017/BatchRvtAddin2017.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BatchRvt.Addin.Revit2017</RootNamespace>
     <AssemblyName>BatchRvtAddin2017</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/BatchRvtAddin2018/BatchRvtAddin2018.csproj
+++ b/BatchRvtAddin2018/BatchRvtAddin2018.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BatchRvt.Addin.Revit2018</RootNamespace>
     <AssemblyName>BatchRvtAddin2018</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/BatchRvtAddin2019/BatchRvtAddin2019.csproj
+++ b/BatchRvtAddin2019/BatchRvtAddin2019.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BatchRvt.Addin.Revit2019</RootNamespace>
     <AssemblyName>BatchRvtAddin2019</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/BatchRvtAddin2020/BatchRvtAddin2020.csproj
+++ b/BatchRvtAddin2020/BatchRvtAddin2020.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BatchRvt.Addin.Revit2020</RootNamespace>
     <AssemblyName>BatchRvtAddin2020</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/BatchRvtGUI/BatchRvtGUI.csproj
+++ b/BatchRvtGUI/BatchRvtGUI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BatchRvtGUI</RootNamespace>
     <AssemblyName>BatchRvtGUI</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup>

--- a/BatchRvtScriptHost/BatchRvtScriptHost.csproj
+++ b/BatchRvtScriptHost/BatchRvtScriptHost.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BatchRvt.ScriptHost</RootNamespace>
     <AssemblyName>BatchRvtScriptHost</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/BatchRvtUtil/BatchRvtUtil.csproj
+++ b/BatchRvtUtil/BatchRvtUtil.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BatchRvtUtil</RootNamespace>
     <AssemblyName>BatchRvtUtil</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
Purpose migrating to .NET Framework 4.8. This _should_ provide the same functionality, but I have not tested in every Revit instance.

I started this because R15 / R16 still utilized .NET Framework 4.5, which has reached end of life. The developer pack can no longer be downloaded from Microsoft, to my knowledge. 

This removes the requirement of having to download 4.5, 4.7, and 4.8 (and in the future over to the .NET streamlined instances).

Can confirm a successful build after these modifications.