### PR TITLE
Add support for dialogs displayed in Spanish

### DIFF
--- a/BatchRvtUtil/Scripts/revit_dialog_detection.py
+++ b/BatchRvtUtil/Scripts/revit_dialog_detection.py
@@ -32,9 +32,17 @@ MODEL_UPGRADE_WINDOW_TITLE = "Model Upgrade"
 LOAD_LINK_WINDOW_TITLE = "Load Link"
 CHANGES_NOT_SAVED_TITLE = "Changes Not Saved"
 CLOSE_PROJECT_WITHOUT_SAVING_TITLE = "Close Project Without Saving"
+CERRAR_PROYECTO_SIN_GUARDAR = "Cerrar proyecto sin guardar"
 SAVE_FILE_WINDOW_TITLE = "Save File"
 EDITABLE_ELEMENTS_TITLE = "Editable Elements"
 AUTODESK_CUSTOMER_INVOLVEMENT_PROGRAM_TITLE = "Autodesk Customer Involvement Program"
+CAMBIOS_NO_GUARDADOS_TITLE = "Cambios no guardados"
+ELEMENTS_LOST_ON_IMPORT_TITLE = "Elements Lost on Import"
+REFERENCIAS_TITLE = "Referencias sin resolver"
+CAMBIOS_TITLE = "Cambios locales no sincronizados con archivo central"
+CHANGES_TITLE = "Local Changes Not Synchronized with Central"
+NWC_TITLE = "Navisworks NWC Exporter"
+REVIT_TITLE = "Revit"
 OPENING_WORKSETS_TITLES = [
         "Worksets",
         "Opening Worksets"
@@ -44,16 +52,26 @@ DIRECTUI_CLASS_NAME = "DirectUIHWND"
 CTRLNOTIFYSINK_CLASS_NAME = "CtrlNotifySink"
 BUTTON_CLASS_NAME = "Button"
 STATIC_CONTROL_CLASS_NAME = "Static"
-
+CANCELAR_BUTTON_TEXT = "Cancelar"
 CLOSE_BUTTON_TEXT = "Close"
+CERRAR_BUTTON_TEXT = "Cerrar"
+ACEPTAR_BUTTON_TEXT = "Aceptar"
+CEDER_TODO_BUTTON_TEXT = "Ceder todos los elementos y subproyectos"
+CEDER_BUTTON_TEXT = "Ceder los elementos y subproyectos"
 OK_BUTTON_TEXT = "OK"
+IGNORAR_BUTTON_TEXT = "Ignorar y abrir el proyecto"
+NO_GUARDAR_PROYECTO_BUTTON_TEXT = "No guardar el proyecto"
 NO_BUTTON_TEXT = "No"
 YES_BUTTON_TEXT = "Yes"
 ALWAYS_LOAD_BUTTON_TEXT = "Always Load"
 CANCEL_LINK_BUTTON_TEXT = "Cancel Link"
 DO_NOT_SAVE_THE_PROJECT_TEXT = "Do not save the project"
+CERRAR_ARCHIVO_LOCAL_BUTTON_TEXT = "Cerrar el archivo local"
+CLOSE_LOCAL_FILE_BUTTON_TEXT = "Close the local file"
+
 RELINQUISH_ALL_ELEMENTS_AND_WORKSETS_TEXT = "Relinquish all elements and worksets"
 RELINQUISH_ELEMENTS_AND_WORKSETS_TEXT = "Relinquish elements and worksets"
+
 
 HAVE_REPORTED_BATCH_RVT_ERROR_WINDOW_DETECTION = [False]
 
@@ -75,9 +93,16 @@ class RevitDialogInfo:
 
 def SendButtonClick(buttons, output):
     okButtons = ui_automation_util.FilterControlsByText(buttons, OK_BUTTON_TEXT)
+    aceptarButtons = ui_automation_util.FilterControlsByText(buttons, ACEPTAR_BUTTON_TEXT)
+    ignorarButtons = ui_automation_util.FilterControlsByText(buttons, IGNORAR_BUTTON_TEXT)
+    cederButtons = ui_automation_util.FilterControlsByText(buttons, CEDER_BUTTON_TEXT)
+    cerrarButtons = ui_automation_util.FilterControlsByText(buttons, CERRAR_BUTTON_TEXT)
+    noGuardarButtons = ui_automation_util.FilterControlsByText(buttons, NO_GUARDAR_PROYECTO_BUTTON_TEXT)
     closeButtons = ui_automation_util.FilterControlsByText(buttons, CLOSE_BUTTON_TEXT)
     noButtons = ui_automation_util.FilterControlsByText(buttons, NO_BUTTON_TEXT)
     alwaysLoadButtons = ui_automation_util.FilterControlsByText(buttons, ALWAYS_LOAD_BUTTON_TEXT)
+    cerrarLocalButtons = ui_automation_util.FilterControlsByText(buttons, CERRAR_ARCHIVO_LOCAL_BUTTON_TEXT)
+    closeLocalButtons = ui_automation_util.FilterControlsByText(buttons, CLOSE_LOCAL_FILE_BUTTON_TEXT)
 
     if len(okButtons) == 1:
         targetButton = okButtons[0]
@@ -87,6 +112,21 @@ def SendButtonClick(buttons, output):
         targetButton = noButtons[0]
     elif len(alwaysLoadButtons) == 1:
         targetButton = alwaysLoadButtons[0]
+    elif len(ignorarButtons) == 1:
+        targetButton = ignorarButtons[0]
+    elif len(noGuardarButtons) == 1:
+        targetButton = noGuardarButtons[0]
+    elif len(cederButtons) == 1:
+        targetButton = cederButtons[0]
+    elif len(cerrarButtons) == 1:
+        targetButton = cerrarButtons[0]
+    elif len(aceptarButtons) == 1:
+        targetButton = aceptarButtons[0]
+    elif len(cerrarLocalButtons) == 1:
+        targetButton = aceptarButtons[0]
+    elif len(closeLocalButtons) == 1:
+        targetButton = aceptarButtons[0]
+
     else:
         output()
         output("WARNING: Could not find suitable button to click.")
@@ -172,6 +212,39 @@ def DismissCheekyRevitDialogBoxes(revitProcessId, output_):
                 output()
                 output("'" + enabledDialog.WindowText + "' dialog box detected.")
                 DismissRevitDialogBox(enabledDialog.WindowText, buttons, RELINQUISH_ELEMENTS_AND_WORKSETS_TEXT, output)
+            elif enabledDialog.WindowText == CAMBIOS_NO_GUARDADOS_TITLE and len(buttons) == 4:
+                output()
+                output("'" + enabledDialog.WindowText + "' dialog box detected.")
+                DismissRevitDialogBox(enabledDialog.WindowText, buttons, NO_GUARDAR_PROYECTO_BUTTON_TEXT, output)
+            elif enabledDialog.WindowText == CERRAR_PROYECTO_SIN_GUARDAR and len(buttons) == 3:
+                output()
+                output("'" + enabledDialog.WindowText + "' dialog box detected.")
+                DismissRevitDialogBox(enabledDialog.WindowText, buttons, CEDER_TODO_BUTTON_TEXT, output)
+            elif enabledDialog.WindowText == REFERENCIAS_TITLE and len(buttons) == 2:
+                output()
+                output("'" + enabledDialog.WindowText + "' dialog box detected.")
+                DismissRevitDialogBox(enabledDialog.WindowText, buttons, IGNORAR_BUTTON_TEXT, output)
+            elif enabledDialog.WindowText == NWC_TITLE and len(buttons) == 1:
+                output()
+                output("'" + enabledDialog.WindowText + "' dialog box detected.")
+                DismissRevitDialogBox(enabledDialog.WindowText, buttons, ACEPTAR_BUTTON_TEXT, output)
+            elif enabledDialog.WindowText == REVIT_TITLE and len(buttons) == 1:
+                output()
+                output("'" + enabledDialog.WindowText + "' dialog box detected.")
+                DismissRevitDialogBox(enabledDialog.WindowText, buttons, ACEPTAR_BUTTON_TEXT, output)
+            elif enabledDialog.WindowText == CAMBIOS_TITLE and len(buttons) == 3:
+                output()
+                output("'" + enabledDialog.WindowText + "' dialog box detected.")
+                DismissRevitDialogBox(enabledDialog.WindowText, buttons, CERRAR_ARCHIVO_LOCAL_BUTTON_TEXT, output)
+            elif enabledDialog.WindowText == CHANGES_TITLE and len(buttons) == 3:
+                output()
+                output("'" + enabledDialog.WindowText + "' dialog box detected.")
+                DismissRevitDialogBox(enabledDialog.WindowText, buttons, CLOSE_LOCAL_FILE_BUTTON_TEXT, output)
+            elif enabledDialog.WindowText == ELEMENTS_LOST_ON_IMPORT_TITLE and len(buttons) == 1:
+                output()
+                output("'" + enabledDialog.WindowText + "' dialog box detected.")
+                DismissRevitDialogBox(enabledDialog.WindowText, buttons, CERRAR_BUTTON_TEXT, output)
+                #######
             elif enabledDialog.WindowText in ["Revit", str.Empty] and len(buttons) == 0 and len(win32Buttons) > 0:
                 output()
                 output("'" + enabledDialog.WindowText + "' dialog box detected.")


### PR DESCRIPTION
Added support for dialogs displayed in the Spanish version of Revit. The code's been tested and it's working just as it works with the English Version. 