### PR TITLE
Update revit_dialog_detection.py

### DIFF
--- a/BatchRvtUtil/Scripts/revit_dialog_detection.py
+++ b/BatchRvtUtil/Scripts/revit_dialog_detection.py
@@ -204,6 +204,10 @@ def DismissCheekyRevitDialogBoxes(revitProcessId, output_):
                 output()
                 output("'" + enabledDialog.WindowText + "' dialog box detected.")
                 DismissRevitDialogBox(enabledDialog.WindowText, buttons, DO_NOT_SAVE_THE_PROJECT_TEXT, output)
+            elif enabledDialog.WindowText == CHANGES_NOT_SAVED_TITLE and len(buttons) == 3:
+                output()
+                output("'" + enabledDialog.WindowText + "' dialog box detected.")
+                DismissRevitDialogBox(enabledDialog.WindowText, buttons, DO_NOT_SAVE_THE_PROJECT_TEXT, output)
             elif enabledDialog.WindowText == CLOSE_PROJECT_WITHOUT_SAVING_TITLE and len(buttons) == 3:
                 output()
                 output("'" + enabledDialog.WindowText + "' dialog box detected.")


### PR DESCRIPTION
Fixed Revit 2024 hang-up when "Changes not saved" dialog box shown, only 3 buttons shown, not 4 as previously shown.